### PR TITLE
Added `out_path` option to transform functions

### DIFF
--- a/babeljs/transformer.py
+++ b/babeljs/transformer.py
@@ -19,20 +19,25 @@ class Transformer(object):
         except:
             raise TransformError()
 
-    def transform_string(self, js, **opts):
+    def transform_string(self, js, out_path=None, **opts):
         try:
-            return self.context.call('babel.transform', js, opts)
+            out = self.context.call('babel.transform', js, opts)
         except execjs.ProgramError as e:
             raise TransformError(e.message[7:])
+        if out_path:
+            with open(out_path, 'w') as f:
+                f.write(out)
+        return out
 
-    def transform(self, js_path, **opts):
-        with open(js_path, 'r') as f:
+    def transform(self, in_path, **opts):
+        with open(in_path, 'r') as f:
             return self.transform_string(f.read(), **opts)
 
 
-def transform(js_path, **opts):
-    return Transformer().transform(js_path, **opts)
+
+def transform(*args, **opts):
+    return Transformer().transform(*args, **opts)
 
 
-def transform_string(js, **opts):
-    return Transformer().transform_string(js, **opts)
+def transform_string(*args, **opts):
+    return Transformer().transform_string(*args, **opts)


### PR DESCRIPTION
A user can specify a path if they want their transpiled JS to output to a file.  For example:

t = babeljs.transformer
t.transform('my/js-6/index.js', 'my/js/index.js')

and the file my/js/index.js will be created with the appropriate output.

If you would like me to write a test for this new functionality, I would be happy to!  Thanks for considering this pull request! :)
