### PR TITLE
Exclude tests in find_packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     license='MIT License',
     author='yetone',
     author_email='i@yetone.net',
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests']),
     platforms='any',
     include_package_data=True,
     tests_require=(


### PR DESCRIPTION
Otherwise `tests` will be installed as a package and cause issues in some build system ( eg. gentoo ebuild).
